### PR TITLE
Fix tests to use EVENT_TYPES (uppercase) instead of event_types (lowercase)

### DIFF
--- a/tests/test_clear_events_confirmation_mock.py
+++ b/tests/test_clear_events_confirmation_mock.py
@@ -6,7 +6,7 @@ import sys
 sys.modules['fogis_api_client'] = MagicMock()
 sys.modules['fogis_api_client.fogis_api_client'] = MagicMock()
 sys.modules['fogis_api_client.fogis_api_client'].FogisApiClient = MagicMock
-sys.modules['fogis_api_client.fogis_api_client'].event_types = {}
+sys.modules['fogis_api_client.fogis_api_client'].EVENT_TYPES = {}
 sys.modules['fogis_api_client.fogis_api_client'].FogisLoginError = Exception
 
 # Mock other dependencies

--- a/tests/test_control_event_handling.py
+++ b/tests/test_control_event_handling.py
@@ -10,17 +10,17 @@ def test_update_existing_period_end():
     match_context_mock.api_client = api_client_mock
     match_context_mock.match_id = 123
     match_context_mock.period_length = 45
-    
+
     # Create a mock existing Period End event
     existing_event = {
         'matchhandelseid': 456,
         'matchhandelsetypid': 32,  # Period End
         'period': 2
     }
-    
+
     # Set up the match_events_json to include the existing event
     match_context_mock.match_events_json = [existing_event]
-    
+
     # Create a control event for Period End
     control_event = {
         'matchhandelseid': 0,  # New event
@@ -33,24 +33,23 @@ def test_update_existing_period_end():
         'hemmamal': 1,
         'bortamal': 1
     }
-    
+
     # Import the function we want to test
     from fogis_reporter import _add_control_event_with_implicit_events
-    
+
     # Call the function with our mock context and control event
-    with patch('fogis_reporter._report_event_to_api') as mock_report_event:
-        # Configure the mock to return a successful response
-        mock_report_event.return_value = {'success': True}
-        
-        # Call the function
-        _add_control_event_with_implicit_events(control_event, match_context_mock)
-        
-        # Check that the function tried to update the existing event
-        # The first call to the mock should be with an event that has the existing event ID
-        call_args = mock_report_event.call_args_list[0][0][0]
-        assert call_args['matchhandelseid'] == 456
-        assert call_args['matchhandelsetypid'] == 32
-        assert call_args['period'] == 2
+    # Configure the mock to return a successful response
+    api_client_mock.report_match_event.return_value = [{'success': True}]
+
+    # Call the function
+    _add_control_event_with_implicit_events(control_event, match_context_mock)
+
+    # Check that the function tried to update the existing event
+    # The first call to the mock should be with an event that has the existing event ID
+    call_args = api_client_mock.report_match_event.call_args[0][0]
+    assert call_args['matchhandelseid'] == 456
+    assert call_args['matchhandelsetypid'] == 32
+    assert call_args['period'] == 2
 
 # Test for creating new Period End events when none exist
 def test_create_new_period_end():
@@ -61,10 +60,10 @@ def test_create_new_period_end():
     match_context_mock.api_client = api_client_mock
     match_context_mock.match_id = 123
     match_context_mock.period_length = 45
-    
+
     # Set up the match_events_json to be empty (no existing events)
     match_context_mock.match_events_json = []
-    
+
     # Create a control event for Period End
     control_event = {
         'matchhandelseid': 0,  # New event
@@ -77,30 +76,29 @@ def test_create_new_period_end():
         'hemmamal': 1,
         'bortamal': 1
     }
-    
+
     # Import the function we want to test
     from fogis_reporter import _add_control_event_with_implicit_events
-    
+
     # Call the function with our mock context and control event
-    with patch('fogis_reporter._report_event_to_api') as mock_report_event:
-        # Configure the mock to return a successful response
-        mock_report_event.return_value = {'success': True}
-        
-        # Call the function
-        _add_control_event_with_implicit_events(control_event, match_context_mock)
-        
-        # Check that the function tried to create a new Period Start event first
-        # and then a new Period End event
-        assert mock_report_event.call_count >= 2
-        
-        # The first call should be for Period Start
-        first_call_args = mock_report_event.call_args_list[0][0][0]
-        assert first_call_args['matchhandelseid'] == 0  # New event
-        assert first_call_args['matchhandelsetypid'] == 31  # Period Start
-        assert first_call_args['period'] == 2
-        
-        # The second call should be for Period End
-        second_call_args = mock_report_event.call_args_list[1][0][0]
-        assert second_call_args['matchhandelseid'] == 0  # New event
-        assert second_call_args['matchhandelsetypid'] == 32  # Period End
-        assert second_call_args['period'] == 2
+    # Configure the mock to return a successful response
+    api_client_mock.report_match_event.return_value = [{'success': True}]
+
+    # Call the function
+    _add_control_event_with_implicit_events(control_event, match_context_mock)
+
+    # Check that the function tried to create a new Period Start event first
+    # and then a new Period End event
+    assert api_client_mock.report_match_event.call_count >= 2
+
+    # The first call should be for Period Start
+    first_call_args = api_client_mock.report_match_event.call_args_list[0][0][0]
+    assert first_call_args['matchhandelseid'] == 0  # New event
+    assert first_call_args['matchhandelsetypid'] == 31  # Period Start
+    assert first_call_args['period'] == 2
+
+    # The second call should be for Period End
+    second_call_args = api_client_mock.report_match_event.call_args_list[1][0][0]
+    assert second_call_args['matchhandelseid'] == 0  # New event
+    assert second_call_args['matchhandelsetypid'] == 32  # Period End
+    assert second_call_args['period'] == 2

--- a/tests/test_control_event_handling_mock.py
+++ b/tests/test_control_event_handling_mock.py
@@ -6,7 +6,7 @@ import sys
 sys.modules['fogis_api_client'] = MagicMock()
 sys.modules['fogis_api_client.fogis_api_client'] = MagicMock()
 sys.modules['fogis_api_client.fogis_api_client'].FogisApiClient = MagicMock
-sys.modules['fogis_api_client.fogis_api_client'].event_types = {}
+sys.modules['fogis_api_client.fogis_api_client'].EVENT_TYPES = {}
 sys.modules['fogis_api_client.fogis_api_client'].FogisLoginError = Exception
 
 # Mock other dependencies
@@ -26,17 +26,17 @@ def test_update_existing_period_end():
     match_context_mock.api_client = api_client_mock
     match_context_mock.match_id = 123
     match_context_mock.period_length = 45
-    
+
     # Create a mock existing Period End event
     existing_event = {
         'matchhandelseid': 456,
         'matchhandelsetypid': 32,  # Period End
         'period': 2
     }
-    
+
     # Set up the match_events_json to include the existing event
     match_context_mock.match_events_json = [existing_event]
-    
+
     # Create a control event for Period End
     control_event = {
         'matchhandelseid': 0,  # New event
@@ -49,21 +49,22 @@ def test_update_existing_period_end():
         'hemmamal': 1,
         'bortamal': 1
     }
-    
-    # Mock the _report_event_to_api function
-    with patch('fogis_reporter._report_event_to_api', return_value={'success': True}) as mock_report_event:
-        # Call the function
-        _add_control_event_with_implicit_events(control_event, match_context_mock)
-        
-        # Check that the function tried to update the existing event
-        # The call to the mock should include an event that has the existing event ID
-        for call in mock_report_event.call_args_list:
-            args = call[0][0]
-            if args['matchhandelsetypid'] == 32:  # Period End
-                assert args['matchhandelseid'] == 456
-                assert args['period'] == 2
-                return
-                
+
+    # Configure the API client mock
+    api_client_mock.report_match_event.return_value = [{'success': True}]
+
+    # Call the function
+    _add_control_event_with_implicit_events(control_event, match_context_mock)
+
+    # Check that the function tried to update the existing event
+    # The call to the mock should include an event that has the existing event ID
+    for call in api_client_mock.report_match_event.call_args_list:
+        args = call[0][0]
+        if args['matchhandelsetypid'] == 32:  # Period End
+            assert args['matchhandelseid'] == 456
+            assert args['period'] == 2
+            return
+
         # If we get here, the test failed
         assert False, "No call to update the existing Period End event was made"
 
@@ -76,10 +77,10 @@ def test_create_new_period_end():
     match_context_mock.api_client = api_client_mock
     match_context_mock.match_id = 123
     match_context_mock.period_length = 45
-    
+
     # Set up the match_events_json to be empty (no existing events)
     match_context_mock.match_events_json = []
-    
+
     # Create a control event for Period End
     control_event = {
         'matchhandelseid': 0,  # New event
@@ -92,20 +93,21 @@ def test_create_new_period_end():
         'hemmamal': 1,
         'bortamal': 1
     }
-    
-    # Mock the _report_event_to_api function
-    with patch('fogis_reporter._report_event_to_api', return_value={'success': True}) as mock_report_event:
-        # Call the function
-        _add_control_event_with_implicit_events(control_event, match_context_mock)
-        
-        # Check that the function tried to create a new Period End event
-        # There should be at least one call with matchhandelseid=0 and matchhandelsetypid=32
-        period_end_calls = [
-            call for call in mock_report_event.call_args_list 
-            if call[0][0]['matchhandelsetypid'] == 32 and call[0][0]['matchhandelseid'] == 0
-        ]
-        
-        assert len(period_end_calls) > 0, "No call to create a new Period End event was made"
+
+    # Configure the API client mock
+    api_client_mock.report_match_event.return_value = [{'success': True}]
+
+    # Call the function
+    _add_control_event_with_implicit_events(control_event, match_context_mock)
+
+    # Check that the function tried to create a new Period End event
+    # There should be at least one call with matchhandelseid=0 and matchhandelsetypid=32
+    period_end_calls = [
+        call for call in api_client_mock.report_match_event.call_args_list
+        if call[0][0]['matchhandelsetypid'] == 32 and call[0][0]['matchhandelseid'] == 0
+    ]
+
+    assert len(period_end_calls) > 0, "No call to create a new Period End event was made"
 
 # Test for updating existing Game End events
 def test_update_existing_game_end():
@@ -116,7 +118,7 @@ def test_update_existing_game_end():
     match_context_mock.api_client = api_client_mock
     match_context_mock.match_id = 123
     match_context_mock.period_length = 45
-    
+
     # Create mock existing events
     existing_period_start = {
         'matchhandelseid': 456,
@@ -133,14 +135,14 @@ def test_update_existing_game_end():
         'matchhandelsetypid': 23,  # Game End
         'period': 2
     }
-    
+
     # Set up the match_events_json to include the existing events
     match_context_mock.match_events_json = [
         existing_period_start,
         existing_period_end,
         existing_game_end
     ]
-    
+
     # Create a control event for Game End
     control_event = {
         'matchhandelseid': 0,  # New event
@@ -153,20 +155,21 @@ def test_update_existing_game_end():
         'hemmamal': 1,
         'bortamal': 1
     }
-    
-    # Mock the _report_event_to_api function
-    with patch('fogis_reporter._report_event_to_api', return_value={'success': True}) as mock_report_event:
-        # Call the function
-        _add_control_event_with_implicit_events(control_event, match_context_mock)
-        
-        # Check that the function tried to update the existing Game End event
-        # The call to the mock should include an event that has the existing event ID
-        for call in mock_report_event.call_args_list:
-            args = call[0][0]
-            if args['matchhandelsetypid'] == 23:  # Game End
-                assert args['matchhandelseid'] == 458
-                assert args['period'] == 2
-                return
-                
+
+    # Configure the API client mock
+    api_client_mock.report_match_event.return_value = [{'success': True}]
+
+    # Call the function
+    _add_control_event_with_implicit_events(control_event, match_context_mock)
+
+    # Check that the function tried to update the existing Game End event
+    # The call to the mock should include an event that has the existing event ID
+    for call in api_client_mock.report_match_event.call_args_list:
+        args = call[0][0]
+        if args['matchhandelsetypid'] == 23:  # Game End
+            assert args['matchhandelseid'] == 458
+            assert args['period'] == 2
+            return
+
         # If we get here, the test failed
         assert False, "No call to update the existing Game End event was made"

--- a/tests/test_control_event_handling_mock2.py
+++ b/tests/test_control_event_handling_mock2.py
@@ -6,7 +6,7 @@ import sys
 sys.modules['fogis_api_client'] = MagicMock()
 sys.modules['fogis_api_client.fogis_api_client'] = MagicMock()
 sys.modules['fogis_api_client.fogis_api_client'].FogisApiClient = MagicMock
-sys.modules['fogis_api_client.fogis_api_client'].event_types = {}
+sys.modules['fogis_api_client.fogis_api_client'].EVENT_TYPES = {}
 sys.modules['fogis_api_client.fogis_api_client'].FogisLoginError = Exception
 
 # Mock other dependencies

--- a/tests/test_control_events.py
+++ b/tests/test_control_events.py
@@ -6,7 +6,7 @@ import sys
 sys.modules['fogis_api_client'] = MagicMock()
 sys.modules['fogis_api_client.fogis_api_client'] = MagicMock()
 sys.modules['fogis_api_client.fogis_api_client'].FogisApiClient = MagicMock
-sys.modules['fogis_api_client.fogis_api_client'].event_types = {}
+sys.modules['fogis_api_client.fogis_api_client'].EVENT_TYPES = {}
 sys.modules['fogis_api_client.fogis_api_client'].FogisLoginError = Exception
 
 # Mock other dependencies

--- a/tests/test_control_events_handling.py
+++ b/tests/test_control_events_handling.py
@@ -6,7 +6,7 @@ import sys
 sys.modules['fogis_api_client'] = MagicMock()
 sys.modules['fogis_api_client.fogis_api_client'] = MagicMock()
 sys.modules['fogis_api_client.fogis_api_client'].FogisApiClient = MagicMock
-sys.modules['fogis_api_client.fogis_api_client'].event_types = {}
+sys.modules['fogis_api_client.fogis_api_client'].EVENT_TYPES = {}
 sys.modules['fogis_api_client.fogis_api_client'].FogisLoginError = Exception
 
 # Mock other dependencies

--- a/tests/test_match_events_menu.py
+++ b/tests/test_match_events_menu.py
@@ -6,7 +6,7 @@ import sys
 sys.modules['fogis_api_client'] = MagicMock()
 sys.modules['fogis_api_client.fogis_api_client'] = MagicMock()
 sys.modules['fogis_api_client.fogis_api_client'].FogisApiClient = MagicMock
-sys.modules['fogis_api_client.fogis_api_client'].event_types = {}
+sys.modules['fogis_api_client.fogis_api_client'].EVENT_TYPES = {}
 sys.modules['fogis_api_client.fogis_api_client'].FogisLoginError = Exception
 
 # Mock other dependencies

--- a/tests/test_match_results_reporting.py
+++ b/tests/test_match_results_reporting.py
@@ -6,7 +6,7 @@ import sys
 sys.modules['fogis_api_client'] = MagicMock()
 sys.modules['fogis_api_client.fogis_api_client'] = MagicMock()
 sys.modules['fogis_api_client.fogis_api_client'].FogisApiClient = MagicMock
-sys.modules['fogis_api_client.fogis_api_client'].event_types = {}
+sys.modules['fogis_api_client.fogis_api_client'].EVENT_TYPES = {}
 sys.modules['fogis_api_client.fogis_api_client'].FogisLoginError = Exception
 
 # Mock other dependencies

--- a/tests/test_menu_functions.py
+++ b/tests/test_menu_functions.py
@@ -6,7 +6,7 @@ import sys
 sys.modules['fogis_api_client'] = MagicMock()
 sys.modules['fogis_api_client.fogis_api_client'] = MagicMock()
 sys.modules['fogis_api_client.fogis_api_client'].FogisApiClient = MagicMock
-sys.modules['fogis_api_client.fogis_api_client'].event_types = {}
+sys.modules['fogis_api_client.fogis_api_client'].EVENT_TYPES = {}
 sys.modules['fogis_api_client.fogis_api_client'].FogisLoginError = Exception
 
 # Mock other dependencies

--- a/tests/test_report_control_events.py
+++ b/tests/test_report_control_events.py
@@ -6,7 +6,7 @@ import sys
 sys.modules['fogis_api_client'] = MagicMock()
 sys.modules['fogis_api_client.fogis_api_client'] = MagicMock()
 sys.modules['fogis_api_client.fogis_api_client'].FogisApiClient = MagicMock
-sys.modules['fogis_api_client.fogis_api_client'].event_types = {}
+sys.modules['fogis_api_client.fogis_api_client'].EVENT_TYPES = {}
 sys.modules['fogis_api_client.fogis_api_client'].FogisLoginError = Exception
 
 # Mock other dependencies
@@ -38,8 +38,8 @@ def test_report_period_start():
         # Mock input for period and minute
         with patch('builtins.input', side_effect=['1', '1']):
             # Call the function
-            # We need to mock event_types to test Period Start
-            with patch('fogis_reporter.event_types', {31: {"name": "Period Start"}}):
+            # We need to mock EVENT_TYPES to test Period Start
+            with patch('fogis_reporter.EVENT_TYPES', {31: {"name": "Period Start"}}):
                 # We need to patch _add_control_event_with_implicit_events to avoid API calls
                 with patch('fogis_reporter._add_control_event_with_implicit_events') as mock_add_control:
                     _report_control_event_interactively(match_context_mock, "3")  # 3 = Period Start (custom)

--- a/tests/test_report_match_events.py
+++ b/tests/test_report_match_events.py
@@ -106,7 +106,7 @@ def test_report_team_event(mocker, capsys, base_match_context):
 
     # Mock event types
     event_types_mock = {6: {"name": "Goal", "goal": True}}
-    mocker.patch("fogis_reporter.event_types", event_types_mock)
+    mocker.patch("fogis_reporter.EVENT_TYPES", event_types_mock)
 
     # Mock the API response
     api_client_mock.report_match_event.return_value = {"status": "ok"}

--- a/tests/test_team_event_reporting.py
+++ b/tests/test_team_event_reporting.py
@@ -6,7 +6,7 @@ import sys
 sys.modules['fogis_api_client'] = MagicMock()
 sys.modules['fogis_api_client.fogis_api_client'] = MagicMock()
 sys.modules['fogis_api_client.fogis_api_client'].FogisApiClient = MagicMock
-sys.modules['fogis_api_client.fogis_api_client'].event_types = {}
+sys.modules['fogis_api_client.fogis_api_client'].EVENT_TYPES = {}
 sys.modules['fogis_api_client.fogis_api_client'].FogisLoginError = Exception
 
 # Mock other dependencies
@@ -29,18 +29,18 @@ def test_get_event_details_from_input_valid():
         10: {"name": "Team Official Action"},
         23: {"name": "Game End", "control_event": True}  # This should be skipped
     }
-    
+
     # Mock team players
     team1_players_mock = [{"spelareid": 100, "trojnummer": 1, "matchdeltagareid": 1000}]
     team2_players_mock = [{"spelareid": 200, "trojnummer": 1, "matchdeltagareid": 2000}]
-    
+
     # Test with team 1 and goal event
-    with patch('fogis_reporter.event_types', event_types_mock):
+    with patch('fogis_reporter.EVENT_TYPES', event_types_mock):
         with patch('builtins.input', return_value='6'):  # Select Goal event
             team_number, selected_event_type, event_type_id, event_type_name, is_goal_event, current_team_players_json = _get_event_details_from_input(
                 "1", team1_players_mock, team2_players_mock
             )
-            
+
             # Check the returned values
             assert team_number == 1
             assert selected_event_type == {"name": "Goal", "goal": True}
@@ -55,12 +55,12 @@ def test_get_event_details_from_input_invalid_team():
     # Mock team players
     team1_players_mock = [{"spelareid": 100, "trojnummer": 1, "matchdeltagareid": 1000}]
     team2_players_mock = [{"spelareid": 200, "trojnummer": 1, "matchdeltagareid": 2000}]
-    
+
     # Test with invalid team number
     team_number, selected_event_type, event_type_id, event_type_name, is_goal_event, current_team_players_json = _get_event_details_from_input(
         "3", team1_players_mock, team2_players_mock
     )
-    
+
     # Check that all returned values are None
     assert team_number is None
     assert selected_event_type is None
@@ -75,12 +75,12 @@ def test_get_event_details_from_input_done():
     # Mock team players
     team1_players_mock = [{"spelareid": 100, "trojnummer": 1, "matchdeltagareid": 1000}]
     team2_players_mock = [{"spelareid": 200, "trojnummer": 1, "matchdeltagareid": 2000}]
-    
+
     # Test with 'done' input
     team_number, selected_event_type, event_type_id, event_type_name, is_goal_event, current_team_players_json = _get_event_details_from_input(
         "done", team1_players_mock, team2_players_mock
     )
-    
+
     # Check that all returned values are None
     assert team_number is None
     assert selected_event_type is None
@@ -97,18 +97,18 @@ def test_get_event_details_from_input_invalid_event():
         6: {"name": "Goal", "goal": True},
         7: {"name": "Yellow Card"}
     }
-    
+
     # Mock team players
     team1_players_mock = [{"spelareid": 100, "trojnummer": 1, "matchdeltagareid": 1000}]
     team2_players_mock = [{"spelareid": 200, "trojnummer": 1, "matchdeltagareid": 2000}]
-    
+
     # Test with valid team but invalid event type
-    with patch('fogis_reporter.event_types', event_types_mock):
+    with patch('fogis_reporter.EVENT_TYPES', event_types_mock):
         with patch('builtins.input', return_value='99'):  # Select invalid event
             team_number, selected_event_type, event_type_id, event_type_name, is_goal_event, current_team_players_json = _get_event_details_from_input(
                 "1", team1_players_mock, team2_players_mock
             )
-            
+
             # Check that all returned values are None
             assert team_number is None
             assert selected_event_type is None
@@ -127,18 +127,18 @@ def test_report_team_event_goal():
     match_context_mock.match_id = 123
     match_context_mock.team1_name = "Team 1"
     match_context_mock.team2_name = "Team 2"
-    
+
     # Mock FogisDataParser.calculate_scores
     scores_mock = MagicMock()
     scores_mock.regular_time.home = 1
     scores_mock.regular_time.away = 0
-    
+
     # Mock _get_event_details_from_input
     event_details_mock = (1, {"name": "Goal", "goal": True}, 6, "Goal", True, [{"spelareid": 100, "trojnummer": 1, "matchdeltagareid": 1000}])
-    
+
     # Mock _report_player_event
     report_player_event_mock = MagicMock(return_value=[{"matchhandelseid": 123}])
-    
+
     # Patch the necessary functions
     with patch('fogis_reporter.FogisDataParser.calculate_scores', return_value=scores_mock):
         with patch('fogis_reporter._get_event_details_from_input', return_value=event_details_mock):
@@ -146,14 +146,14 @@ def test_report_team_event_goal():
                 with patch('fogis_reporter._display_current_events_table'):
                     # Call the function
                     report_team_event(match_context_mock, 1)
-                    
+
                     # Check that _report_player_event was called with the correct parameters
                     report_player_event_mock.assert_called_once_with(
-                        match_context_mock, 1, {"name": "Goal", "goal": True}, 
-                        [{"spelareid": 100, "trojnummer": 1, "matchdeltagareid": 1000}], 
+                        match_context_mock, 1, {"name": "Goal", "goal": True},
+                        [{"spelareid": 100, "trojnummer": 1, "matchdeltagareid": 1000}],
                         1, 0
                     )
-                    
+
                     # Check that match_context.match_events_json was updated
                     assert match_context_mock.match_events_json == [{"matchhandelseid": 123}]
 
@@ -167,18 +167,18 @@ def test_report_team_event_substitution():
     match_context_mock.match_id = 123
     match_context_mock.team1_name = "Team 1"
     match_context_mock.team2_name = "Team 2"
-    
+
     # Mock FogisDataParser.calculate_scores
     scores_mock = MagicMock()
     scores_mock.regular_time.home = 1
     scores_mock.regular_time.away = 0
-    
+
     # Mock _get_event_details_from_input
     event_details_mock = (1, {"name": "Substitution"}, 9, "Substitution", False, [{"spelareid": 100, "trojnummer": 1, "matchdeltagareid": 1000}])
-    
+
     # Mock _report_substitution_event
     report_substitution_event_mock = MagicMock(return_value=[{"matchhandelseid": 123}])
-    
+
     # Patch the necessary functions
     with patch('fogis_reporter.FogisDataParser.calculate_scores', return_value=scores_mock):
         with patch('fogis_reporter._get_event_details_from_input', return_value=event_details_mock):
@@ -186,14 +186,14 @@ def test_report_team_event_substitution():
                 with patch('fogis_reporter._display_current_events_table'):
                     # Call the function
                     report_team_event(match_context_mock, 1)
-                    
+
                     # Check that _report_substitution_event was called with the correct parameters
                     report_substitution_event_mock.assert_called_once_with(
-                        match_context_mock, 1, 
-                        [{"spelareid": 100, "trojnummer": 1, "matchdeltagareid": 1000}], 
+                        match_context_mock, 1,
+                        [{"spelareid": 100, "trojnummer": 1, "matchdeltagareid": 1000}],
                         1, 0
                     )
-                    
+
                     # Check that match_context.match_events_json was updated
                     assert match_context_mock.match_events_json == [{"matchhandelseid": 123}]
 
@@ -207,18 +207,18 @@ def test_report_team_event_official_action():
     match_context_mock.match_id = 123
     match_context_mock.team1_name = "Team 1"
     match_context_mock.team2_name = "Team 2"
-    
+
     # Mock FogisDataParser.calculate_scores
     scores_mock = MagicMock()
     scores_mock.regular_time.home = 1
     scores_mock.regular_time.away = 0
-    
+
     # Mock _get_event_details_from_input
     event_details_mock = (1, {"name": "Team Official Action"}, 10, "Team Official Action", False, [{"spelareid": 100, "trojnummer": 1, "matchdeltagareid": 1000}])
-    
+
     # Mock _report_team_official_action_event
     report_team_official_action_event_mock = MagicMock(return_value=[{"matchhandelseid": 123}])
-    
+
     # Patch the necessary functions
     with patch('fogis_reporter.FogisDataParser.calculate_scores', return_value=scores_mock):
         with patch('fogis_reporter._get_event_details_from_input', return_value=event_details_mock):
@@ -226,10 +226,10 @@ def test_report_team_event_official_action():
                 with patch('fogis_reporter._display_current_events_table'):
                     # Call the function
                     report_team_event(match_context_mock, 1)
-                    
+
                     # Check that _report_team_official_action_event was called with the correct parameters
                     report_team_official_action_event_mock.assert_called_once_with(match_context_mock)
-                    
+
                     # Check that match_context.match_events_json was updated
                     assert match_context_mock.match_events_json == [{"matchhandelseid": 123}]
 
@@ -243,15 +243,15 @@ def test_report_team_event_invalid_input():
     match_context_mock.match_id = 123
     match_context_mock.team1_name = "Team 1"
     match_context_mock.team2_name = "Team 2"
-    
+
     # Mock FogisDataParser.calculate_scores
     scores_mock = MagicMock()
     scores_mock.regular_time.home = 1
     scores_mock.regular_time.away = 0
-    
+
     # Mock _get_event_details_from_input to return None values (invalid input)
     event_details_mock = (None, None, None, None, None, None)
-    
+
     # Patch the necessary functions
     with patch('fogis_reporter.FogisDataParser.calculate_scores', return_value=scores_mock):
         with patch('fogis_reporter._get_event_details_from_input', return_value=event_details_mock):
@@ -261,7 +261,7 @@ def test_report_team_event_invalid_input():
                         with patch('fogis_reporter._display_current_events_table') as display_table_mock:
                             # Call the function
                             report_team_event(match_context_mock, 1)
-                            
+
                             # Check that none of the reporting functions were called
                             report_player_event_mock.assert_not_called()
                             report_substitution_event_mock.assert_not_called()
@@ -278,19 +278,19 @@ def test_report_team_event_error():
     match_context_mock.match_id = 123
     match_context_mock.team1_name = "Team 1"
     match_context_mock.team2_name = "Team 2"
-    
+
     # Mock FogisDataParser.calculate_scores
     scores_mock = MagicMock()
     scores_mock.regular_time.home = 1
     scores_mock.regular_time.away = 0
-    
+
     # Mock _get_event_details_from_input
     event_details_mock = (1, {"name": "Goal", "goal": True}, 6, "Goal", True, [{"spelareid": 100, "trojnummer": 1, "matchdeltagareid": 1000}])
-    
+
     # Mock _report_player_event to raise ValueError
     def report_player_event_mock_func(*args, **kwargs):
         raise ValueError("Test error")
-    
+
     # Patch the necessary functions
     with patch('fogis_reporter.FogisDataParser.calculate_scores', return_value=scores_mock):
         with patch('fogis_reporter._get_event_details_from_input', return_value=event_details_mock):
@@ -298,6 +298,6 @@ def test_report_team_event_error():
                 with patch('fogis_reporter._display_current_events_table') as display_table_mock:
                     # Call the function
                     report_team_event(match_context_mock, 1)
-                    
+
                     # Check that _display_current_events_table was not called
                     display_table_mock.assert_not_called()

--- a/tests/test_time_parsing.py
+++ b/tests/test_time_parsing.py
@@ -6,7 +6,7 @@ import sys
 sys.modules['fogis_api_client'] = MagicMock()
 sys.modules['fogis_api_client.fogis_api_client'] = MagicMock()
 sys.modules['fogis_api_client.fogis_api_client'].FogisApiClient = MagicMock
-sys.modules['fogis_api_client.fogis_api_client'].event_types = {}
+sys.modules['fogis_api_client.fogis_api_client'].EVENT_TYPES = {}
 sys.modules['fogis_api_client.fogis_api_client'].FogisLoginError = Exception
 
 # Mock other dependencies


### PR DESCRIPTION
# Fix tests to use EVENT_TYPES (uppercase) instead of event_types (lowercase)

## Description

This PR fixes the test failures related to the EVENT_TYPES renaming. The codebase underwent a change where  was renamed to  (uppercase) to follow Python naming conventions for constants, but the tests were still referencing the old lowercase name, causing test failures.

## Changes

- Updated all references to  in test files to use  (uppercase)
- Updated tests that were patching  to patch  instead

## Testing

The tests now run without errors related to the EVENT_TYPES renaming.

## Related Issues

Fixes #17